### PR TITLE
Jobs should only be posted in an appropriate chan

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Failing to follow the community guidelines as described in this document carries
 
 *The role of the moderators is to be an unbiased mediator, they will not moderate or edit anything written in the Slack unless it is required as a result of a discussed dispute.*
 
-*Job adverts that don't specify the company or require contacting an external recuriter to apply will be removed*
+*Job adverts that don't specify the company or require contacting an external recuriter to apply will be removed.  In addition these should only be posted in an appropriate channel (#freelance-jobs or #perm-jobs).*


### PR DESCRIPTION
Adding a snippet in an effort to combat future job spam. Acting on this - https://frontendlondon.slack.com/archives/general/p1456937721000431

Not sure if it's also worth saying something about highlighting everybody?  That should probably also fall into a separate PR.
